### PR TITLE
feat: support automatic analysis toggle setting

### DIFF
--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -833,6 +833,7 @@ function handleServerRequest(msg) {
       log("→ workspace/configuration:", JSON.stringify(params));
 
       const sonarlintDefaults = {
+        automaticAnalysis: true,
         rules: {},
         disableTelemetry: true,
         output: { showVerboseLogs: false },


### PR DESCRIPTION
## Summary
- Adds `automaticAnalysis: true` as a default in the `workspace/configuration` handler in the Node.js wrapper
- Users can set `"automaticAnalysis": false` in their Zed settings to disable automatic analysis
- The existing `deepMerge` logic ensures user settings override the default

Closes #15

## Test plan
- [x] Open a supported file in Zed — diagnostics should appear as usual (default `true`)
- [x] Set `"automaticAnalysis": false` in Zed LSP settings for sonarlint — diagnostics should stop appearing automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)