### PR TITLE
feat: add integration test harness with real sonarlint-ls

### DIFF
--- a/test/integration/harness.mjs
+++ b/test/integration/harness.mjs
@@ -1,0 +1,258 @@
+import { spawn, execSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir, platform } from 'node:os';
+
+const SONARLINT_VERSION = '4.42.0';
+
+export function findJava() {
+  const javaHome = process.env.JAVA_HOME;
+  if (javaHome) {
+    const javaBin = join(javaHome, 'bin', 'java');
+    if (existsSync(javaBin)) return javaBin;
+  }
+  try {
+    const which = execSync('which java', { encoding: 'utf8' }).trim();
+    if (which) return which;
+  } catch {
+    // not found
+  }
+  return null;
+}
+
+export function findSonarLintJars() {
+  // Allow env var overrides
+  const serverOverride = process.env.SONARLINT_SERVER_PATH;
+  const analyzerOverride = process.env.SONARLINT_ANALYZER_PATHS;
+  if (serverOverride && analyzerOverride) {
+    return {
+      serverJar: serverOverride,
+      analyzerJars: analyzerOverride.split('|').filter(Boolean),
+    };
+  }
+
+  // Search Zed extension work directory
+  let workDir;
+  const p = platform();
+  if (p === 'darwin') {
+    workDir = join(homedir(), 'Library', 'Application Support', 'Zed', 'extensions', 'work', 'sonarlint');
+  } else if (p === 'win32') {
+    workDir = join(process.env.LOCALAPPDATA || '', 'Zed', 'extensions', 'work', 'sonarlint');
+  } else {
+    workDir = join(homedir(), '.local', 'share', 'zed', 'extensions', 'work', 'sonarlint');
+  }
+
+  const installDir = join(workDir, `sonarlint-${SONARLINT_VERSION}`, 'extension');
+  const serverJar = join(installDir, 'server', 'sonarlint-ls.jar');
+  if (!existsSync(serverJar)) return null;
+
+  const analyzersDir = join(installDir, 'analyzers');
+  const analyzerJars = [];
+  if (existsSync(analyzersDir)) {
+    for (const f of readdirSync(analyzersDir)) {
+      if (f.endsWith('.jar')) {
+        analyzerJars.push(join(analyzersDir, f));
+      }
+    }
+  }
+
+  return { serverJar, analyzerJars };
+}
+
+export class LspTestClient {
+  constructor() {
+    this._process = null;
+    this._nextId = 1;
+    this._pending = new Map();
+    this._notifications = [];
+    this._serverRequests = [];
+    this._buffer = Buffer.alloc(0);
+  }
+
+  async start(env) {
+    const projectRoot = resolve(import.meta.dirname, '..', '..');
+    const wrapperPath = join(projectRoot, 'wrapper', 'sonarlint-wrapper.js');
+
+    this._process = spawn('node', [wrapperPath], {
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: projectRoot,
+    });
+
+    this._process.stdout.on('data', (chunk) => this._onData(chunk));
+    this._process.stderr.on('data', (chunk) => {
+      // Log stderr for debugging but don't fail
+      const text = chunk.toString();
+      if (process.env.TEST_DEBUG) {
+        process.stderr.write(`[wrapper stderr] ${text}`);
+      }
+    });
+
+    this._process.on('error', (err) => {
+      console.error('Wrapper process error:', err);
+    });
+
+    // Give the process a moment to start
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  async stop() {
+    if (!this._process) return;
+    try {
+      await this.request('shutdown', null, 10000);
+    } catch {
+      // ignore
+    }
+    this.notify('exit', null);
+    await new Promise((r) => setTimeout(r, 500));
+    this.kill();
+  }
+
+  kill() {
+    if (this._process) {
+      this._process.kill('SIGKILL');
+      this._process = null;
+    }
+  }
+
+  async request(method, params, timeoutMs = 30000) {
+    const id = this._nextId++;
+    const message = { jsonrpc: '2.0', id, method, params };
+    this._send(message);
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pending.delete(id);
+        reject(new Error(`Request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this._pending.set(id, { resolve, reject, timer });
+    });
+  }
+
+  notify(method, params) {
+    const message = { jsonrpc: '2.0', method, params };
+    this._send(message);
+  }
+
+  respondToRequest(id, result) {
+    const message = { jsonrpc: '2.0', id, result };
+    this._send(message);
+  }
+
+  async waitForDiagnostics(uri, timeoutMs = 30000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const found = this._notifications.find(
+        (n) =>
+          n.method === 'textDocument/publishDiagnostics' &&
+          n.params?.uri === uri &&
+          n.params?.diagnostics?.length > 0
+      );
+      if (found) return found.params;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error(`No diagnostics received for ${uri} within ${timeoutMs}ms`);
+  }
+
+  async waitForNotification(method, timeoutMs = 15000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const found = this._notifications.find((n) => n.method === method);
+      if (found) return found;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error(`No '${method}' notification received within ${timeoutMs}ms`);
+  }
+
+  clearDiagnostics(uri) {
+    this._notifications = this._notifications.filter(
+      (n) =>
+        !(n.method === 'textDocument/publishDiagnostics' && n.params?.uri === uri)
+    );
+  }
+
+  _send(message) {
+    const body = JSON.stringify(message);
+    const header = `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n`;
+    if (this._process?.stdin?.writable) {
+      this._process.stdin.write(header + body);
+    }
+  }
+
+  _onData(chunk) {
+    this._buffer = Buffer.concat([this._buffer, chunk]);
+    this._parseMessages();
+  }
+
+  _parseMessages() {
+    while (true) {
+      const headerEnd = this._buffer.indexOf('\r\n\r\n');
+      if (headerEnd === -1) return;
+
+      const header = this._buffer.slice(0, headerEnd).toString();
+      const match = header.match(/Content-Length:\s*(\d+)/i);
+      if (!match) {
+        // Skip malformed header
+        this._buffer = this._buffer.slice(headerEnd + 4);
+        continue;
+      }
+
+      const contentLength = parseInt(match[1], 10);
+      const bodyStart = headerEnd + 4;
+      if (this._buffer.length < bodyStart + contentLength) return;
+
+      const body = this._buffer.slice(bodyStart, bodyStart + contentLength).toString();
+      this._buffer = this._buffer.slice(bodyStart + contentLength);
+
+      let message;
+      try {
+        message = JSON.parse(body);
+      } catch {
+        continue;
+      }
+
+      this._handleMessage(message);
+    }
+  }
+
+  _handleMessage(message) {
+    // Response to our request
+    if (message.id !== undefined && (message.result !== undefined || message.error !== undefined)) {
+      const pending = this._pending.get(message.id);
+      if (pending) {
+        this._pending.delete(message.id);
+        clearTimeout(pending.timer);
+        if (message.error) {
+          pending.reject(new Error(`LSP error ${message.error.code}: ${message.error.message}`));
+        } else {
+          pending.resolve(message.result);
+        }
+        return;
+      }
+    }
+
+    // Server-initiated request (has id + method)
+    if (message.id !== undefined && message.method !== undefined) {
+      this._serverRequests.push(message);
+      // Auto-respond to common server requests
+      if (
+        message.method === 'client/registerCapability' ||
+        message.method === 'client/unregisterCapability' ||
+        message.method === 'window/showMessageRequest'
+      ) {
+        this.respondToRequest(message.id, null);
+      } else if (message.method === 'workspace/configuration') {
+        // Return empty config for each requested item
+        const items = message.params?.items || [];
+        this.respondToRequest(message.id, items.map(() => ({})));
+      }
+      return;
+    }
+
+    // Notification (no id)
+    if (message.method) {
+      this._notifications.push(message);
+    }
+  }
+}

--- a/test/integration/sonarlint.integration.test.mjs
+++ b/test/integration/sonarlint.integration.test.mjs
@@ -1,0 +1,174 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { LspTestClient, findJava, findSonarLintJars } from './harness.mjs';
+
+const projectRoot = resolve(import.meta.dirname, '..', '..');
+const testFixturesDir = resolve(projectRoot, 'test');
+const javaPath = findJava();
+const jars = findSonarLintJars();
+
+function fileUri(filename) {
+  return pathToFileURL(resolve(testFixturesDir, filename)).href;
+}
+
+function readFixture(filename) {
+  return readFileSync(resolve(testFixturesDir, filename), 'utf8');
+}
+
+describe('SonarLint integration tests', { timeout: 120_000 }, () => {
+  let client;
+
+  if (!javaPath) {
+    console.log('SKIP: Java not found — skipping integration tests');
+    return;
+  }
+  if (!jars) {
+    console.log('SKIP: SonarLint JARs not found — skipping integration tests');
+    return;
+  }
+
+  before(async () => {
+    client = new LspTestClient();
+
+    await client.start({
+      SONARLINT_JAVA_PATH: javaPath,
+      SONARLINT_SERVER_PATH: jars.serverJar,
+      SONARLINT_ANALYZER_PATHS: jars.analyzerJars.join('|'),
+      SONARLINT_DEBUG: '1',
+    });
+
+    const initResult = await client.request('initialize', {
+      processId: process.pid,
+      capabilities: {
+        textDocument: {
+          publishDiagnostics: { relatedInformation: true },
+          synchronization: { dynamicRegistration: false, didSave: true },
+        },
+        workspace: {
+          workspaceFolders: true,
+          didChangeConfiguration: { dynamicRegistration: true },
+          configuration: true,
+        },
+      },
+      rootUri: pathToFileURL(testFixturesDir).href,
+      workspaceFolders: [
+        { uri: pathToFileURL(testFixturesDir).href, name: 'test' },
+      ],
+      initializationOptions: {
+        productKey: 'zed',
+        productName: 'Zed',
+        productVersion: '0.1.0',
+        showVerboseLogs: true,
+        disableTelemetry: true,
+        focusOnNewCode: false,
+        automaticAnalysis: true,
+        connectedModeEmbedded: { shouldManageServerLifetime: false },
+        additionalAttributes: {},
+      },
+    }, 60_000);
+
+    assert.ok(initResult?.capabilities, 'Server should return capabilities');
+
+    client.notify('initialized', {});
+
+    client.notify('workspace/didChangeConfiguration', {
+      settings: {
+        sonarlint: {
+          automaticAnalysis: true,
+          focusOnNewCode: false,
+          rules: {},
+          disableTelemetry: true,
+          output: { showVerboseLogs: true },
+          pathToNodeExecutable: '',
+          connectedMode: {
+            connections: { sonarqube: [], sonarcloud: [] },
+          },
+        },
+      },
+    });
+
+    // Wait for JVM to settle
+    await new Promise((r) => setTimeout(r, 5000));
+  });
+
+  after(async () => {
+    if (client) {
+      await client.stop();
+    }
+  });
+
+  it('should return diagnostics for JavaScript', { timeout: 30_000 }, async () => {
+    const uri = fileUri('example.js');
+    const text = readFixture('example.js');
+
+    client.notify('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId: 'javascript',
+        version: 1,
+        text,
+      },
+    });
+
+    const result = await client.waitForDiagnostics(uri, 30_000);
+    assert.ok(result.diagnostics.length > 0, 'Should have at least one diagnostic');
+    assert.ok(
+      result.diagnostics.some((d) => d.source === 'sonarlint' || d.source === 'sonarqube'),
+      'Diagnostics should come from sonarlint/sonarqube'
+    );
+
+    client.notify('textDocument/didClose', { textDocument: { uri } });
+    client.clearDiagnostics(uri);
+  });
+
+  it('should return diagnostics for Java', { timeout: 30_000 }, async () => {
+    const uri = fileUri('example.java');
+    const text = readFixture('example.java');
+
+    client.notify('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId: 'java',
+        version: 1,
+        text,
+      },
+    });
+
+    const result = await client.waitForDiagnostics(uri, 30_000);
+    assert.ok(result.diagnostics.length > 0, 'Should have at least one diagnostic');
+    assert.ok(
+      result.diagnostics.some((d) => d.source === 'sonarlint' || d.source === 'sonarqube'),
+      'Diagnostics should come from sonarlint/sonarqube'
+    );
+
+    client.notify('textDocument/didClose', { textDocument: { uri } });
+    client.clearDiagnostics(uri);
+  });
+
+  it('should return diagnostics for Python', { timeout: 30_000 }, async () => {
+    const uri = fileUri('example.py');
+    const text = readFixture('example.py');
+
+    client.notify('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId: 'python',
+        version: 1,
+        text,
+      },
+    });
+
+    const result = await client.waitForDiagnostics(uri, 30_000);
+    assert.ok(result.diagnostics.length > 0, 'Should have at least one diagnostic');
+    assert.ok(
+      result.diagnostics.some((d) => d.source === 'sonarlint' || d.source === 'sonarqube'),
+      'Diagnostics should come from sonarlint/sonarqube'
+    );
+
+    client.notify('textDocument/didClose', { textDocument: { uri } });
+    client.clearDiagnostics(uri);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds integration test harness that spawns the real wrapper + sonarlint-ls process chain
- `LspTestClient` class handles LSP message framing, request/response matching, and diagnostic collection
- Single JVM lifecycle per test suite (start once, run all tests, shutdown)
- 3 test cases: JavaScript, Java, and Python diagnostics — all passing (~18s)
- Gracefully skips if Java 17+ or SonarLint JARs are not available

Closes #19

## Test plan
- [ ] Run `node --test test/integration/sonarlint.integration.test.mjs` with Java 17+ installed
- [ ] Verify all 3 tests pass (JS, Java, Python diagnostics)
- [ ] Verify graceful skip when Java or JARs are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)