### PR TITLE
feat: support JVM arguments via sonarlint.ls.vmargs setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for JVM arguments via `sonarlint.ls.vmargs` setting (e.g., `-Xmx2048m` for increased heap memory or `-agentlib:jdwp=...` for remote debugging)
+
 ### Changed
 - Remap diagnostic severities based on Clean Code impact severity instead of using raw SonarLint rule severities
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,14 @@ impl zed::Extension for SonarLintExtension {
                     env.push(("SONARLINT_DEBUG".to_string(), "1".to_string()));
                 }
             }
+            // Read VM args from settings (sonarlint.ls.vmargs)
+            if let Some(ref ws_settings) = settings.settings {
+                if let Some(ls_obj) = ws_settings.get("ls") {
+                    if let Some(vmargs) = ls_obj.get("vmargs").and_then(|v| v.as_str()) {
+                        env.push(("SONARLINT_VM_ARGS".to_string(), vmargs.to_string()));
+                    }
+                }
+            }
         }
 
         Ok(zed::Command {

--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -158,6 +158,7 @@ const RAW_ANALYZERS = (
   .filter(Boolean);
 const JAVA_HOME = process.env.JAVA_HOME || "";
 const DEBUG = process.env.SONARLINT_DEBUG === "1";
+const VM_ARGS = process.env.SONARLINT_VM_ARGS || "";
 
 if (!RAW_SERVER_JAR) {
   process.stderr.write(
@@ -327,7 +328,54 @@ function listFilesInFolder(folderUri) {
 
 // ─── Spawn SonarLint Language Server ─────────────────────────────────────────
 
-const javaArgs = ["-Xmx1024m", "-Xms128m", "-jar", SERVER_JAR, "-stdio"];
+/**
+ * Parse VM arguments string into an array, respecting quoted strings.
+ * Example: '-Xmx1024m -Dfoo="bar baz"' → ['-Xmx1024m', '-Dfoo=bar baz']
+ */
+function parseVmArgs(argsString) {
+  if (!argsString || !argsString.trim()) {
+    return [];
+  }
+  const args = [];
+  let current = "";
+  let inQuote = false;
+  let quoteChar = "";
+
+  for (let i = 0; i < argsString.length; i++) {
+    const char = argsString[i];
+    if (!inQuote && (char === '"' || char === "'")) {
+      inQuote = true;
+      quoteChar = char;
+    } else if (inQuote && char === quoteChar) {
+      inQuote = false;
+      quoteChar = "";
+    } else if (!inQuote && char === " ") {
+      if (current.trim()) {
+        args.push(current.trim());
+      }
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    args.push(current.trim());
+  }
+  return args;
+}
+
+// Use user-provided VM args or fall back to defaults
+const defaultVmArgs = ["-Xmx1024m", "-Xms128m"];
+const userVmArgs = parseVmArgs(VM_ARGS);
+const vmArgs = userVmArgs.length > 0 ? userVmArgs : defaultVmArgs;
+
+if (userVmArgs.length > 0) {
+  log("Using custom VM args:", vmArgs.join(" "));
+} else {
+  log("Using default VM args:", vmArgs.join(" "));
+}
+
+const javaArgs = [...vmArgs, "-jar", SERVER_JAR, "-stdio"];
 
 if (ANALYZERS.length > 0) {
   javaArgs.push("-analyzers");


### PR DESCRIPTION
Allow users to configure custom JVM arguments for the SonarLint language server. This enables use cases like increasing heap memory (-Xmx2048m), setting JVM properties, or enabling remote debugging.

Configuration example:
{
  "lsp": {
    "sonarlint": {
      "settings": {
        "ls": { "vmargs": "-Xmx2048m" }
      }
    }
  }
}

Closes #3

https://claude.ai/code/session_011zJM9bScdfCSF4YJdR5F92