### PR TITLE
fix: don't modify fully qualified project keys and fix case-sensitivity issue

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
+fi
+
+export DEVENV_IN_DIRENV_SHELL=true
+
+watch_dir nix
+
+mkdir -p "$PWD/.devenv"
+DEVENV_ROOT_FILE="$PWD/.devenv/root"
+printf %s "$PWD" >"$DEVENV_ROOT_FILE"
+
+if ! use flake ./nix --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"; then
+  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes and hit enter to try again." >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ yarn-error.log*
 # Temporary files
 *.tmp
 *.bak
+
+# Nix tooling
+.devenv
+.direnv

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed architecture documentation and develop
 ### Build the extension
 
 ```bash
-cargo build --release
+cargo build --release --target wasm32-wasip2
 ```
 
 ### Prerequisites for development

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,1157 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "cachix_2": {
+      "inputs": {
+        "devenv": [
+          "devenv",
+          "crate2nix"
+        ],
+        "flake-compat": [
+          "devenv",
+          "crate2nix"
+        ],
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1767714506,
+        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "cachix_3": {
+      "inputs": {
+        "devenv": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "git-hooks": "git-hooks_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1767714506,
+        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "inputs": {
+        "cachix": "cachix_2",
+        "crate2nix_stable": "crate2nix_stable",
+        "devshell": "devshell_2",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_2",
+        "nix-test-runner": "nix-test-runner_2",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "crate2nix_stable": {
+      "inputs": {
+        "cachix": "cachix_3",
+        "crate2nix_stable": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nix-test-runner": "nix-test-runner",
+        "nixpkgs": "nixpkgs_3",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1769627083,
+        "narHash": "sha256-SUuruvw1/moNzCZosHaa60QMTL+L9huWdsCBN6XZIic=",
+        "owner": "nix-community",
+        "repo": "crate2nix",
+        "rev": "7c33e664668faecf7655fa53861d7a80c9e464a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "0.15.0",
+        "repo": "crate2nix",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_3",
+        "ghostty": "ghostty",
+        "git-hooks": "git-hooks_3",
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": "nixpkgs_6",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1778814374,
+        "narHash": "sha256-gZIaq9to5brzEsnlHE2D0FRN4ixZJEBd2ZV/3WNlt4Q=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e44d88a683bf945c72445babd85f1d2e4e933409",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv-root": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
+        "type": "file",
+        "url": "file:///dev/null"
+      },
+      "original": {
+        "type": "file",
+        "url": "file:///dev/null"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_2": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems",
+        "zig": "zig",
+        "zon2nix": "zon2nix"
+      },
+      "locked": {
+        "lastModified": 1777773742,
+        "narHash": "sha256-dZFc+8az7BUIs8+v45XqNnY5G6oXEwVfVVHZQuATSGQ=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "1547dd667ab6d1f4ebcdc7282adc54c95752ee67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765404074,
+        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765404074,
+        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_5",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_4": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_5": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770586272,
+        "narHash": "sha256-Ucci8mu8QfxwzyfER2DQDbvW9t1BnTUJhBmY7ybralo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "b1f916ba052341edc1f80d4b2399f1092a4873ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "mk-shell-bin": {
+      "locked": {
+        "lastModified": 1677004959,
+        "narHash": "sha256-/uEkr1UkJrh11vD02aqufCxtbF5YnhRTIKlx5kyvf+I=",
+        "owner": "rrbutani",
+        "repo": "nix-mk-shell-bin",
+        "rev": "ff5d8bd4d68a347be5042e2f16caee391cd75887",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rrbutani",
+        "repo": "nix-mk-shell-bin",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776511668,
+        "narHash": "sha256-g2KEBuHpc3a56c+jPcg0+w6LSuIj6f+zzdztLCOyIhc=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "42d4b7de21c15f28c568410f4383fa06a8458a40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-test-runner": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588761593,
+        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "type": "github"
+      }
+    },
+    "nix-test-runner_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588761593,
+        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767430085,
+        "narHash": "sha256-SiXJ6xv4pS2MDUqfj0/mmG746cGeJrMQGmoFgHLS25Y=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "66f4b8a47e92aa744ec43acbb5e9185078983909",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": "nixpkgs_5",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1777345723,
+        "narHash": "sha256-BhY3D5DhpDnnUcaY+AL/cpyYX+OIjQgnAkbPLZ08C38=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "6bf30951a3dc407a798d30db427e3f96ac9b39f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769922788,
+        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1769433173,
+        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1770537093,
+        "narHash": "sha256-XV30uo8tXuxdzuV8l3sojmlPRLd/8tpMsOp4lNzLGUo=",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre942631.fef9403a3e4d/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-wMN1gM00sUQ2KC9CNr/XEOGdfOrl67PabIRv9AYayTo=",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre985613.0726a0ecb6d4/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_6": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1776852779,
+        "narHash": "sha256-WwO/ITisCXwyiRgtktZgv3iGhAGO+IB5Av4kKCwezR0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "ec3063523dcd911aeadb50faa589f237cdab5853",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src_2"
+      },
+      "locked": {
+        "lastModified": 1770434727,
+        "narHash": "sha256-YzOZRgiqIccnkkZvckQha7wvOfN2z50xEdPvfgu6sf8=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8430f16a39c27bdeef236f1eeb56f0b51b33d348",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_4",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "devenv-root": "devenv-root",
+        "flake-parts": "flake-parts_4",
+        "mk-shell-bin": "mk-shell-bin",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs_7",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "rust-overlay": "rust-overlay_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777778183,
+        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778815121,
+        "narHash": "sha256-xlhD+1NVJbhrUUM2usRHW6iKWTXP2uw2Fo6sWJmLg8g=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "017351829a9356423afd2cca0dde9b63346c8ab3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "ghostty",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ],
+        "systems": [
+          "devenv",
+          "ghostty",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776789209,
+        "narHash": "sha256-G6B7Q4TXn7MZ1mB+f9rymjsYF5PLWoSvmbxijb/99bw=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "14fe971844e841297ddd2ce9783d6892b467af39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
+    "zig_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "zon2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777234348,
+        "narHash": "sha256-fKw44a4qbUuI5eTG8k0gPbqMV5TOrjYF35PBzsYgd2U=",
+        "ref": "refs/heads/main",
+        "rev": "2c781c0609ecda600ab98f98cca417bbd981bd53",
+        "revCount": 1677,
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      }
+    },
+    "zon2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ],
+        "zig": "zig_2"
+      },
+      "locked": {
+        "lastModified": 1777314365,
+        "narHash": "sha256-eLxQaD0wc96Neqkln8wHS0rNq/chPODifFkhwrwilEU=",
+        "owner": "jcollie",
+        "repo": "zon2nix",
+        "rev": "a5a1d412ad1ab6305511997bbc92b3a9dd6cb784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jcollie",
+        "ref": "main",
+        "repo": "zon2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    devenv-root = {
+      url = "file+file:///dev/null";
+      flake = false;
+    };
+    nixpkgs.url = "github:cachix/devenv-nixpkgs/rolling";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+    devenv.url = "github:cachix/devenv";
+    nix2container.url = "github:nlewo/nix2container";
+    nix2container.inputs.nixpkgs.follows = "nixpkgs";
+    mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
+
+    # User-defined inputs
+    nixpkgs-unstable = {
+      url = "github:NixOS/nixpkgs/nixos-unstable";
+    };
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs = { nixpkgs.follows = "nixpkgs"; };
+  };
+
+  nixConfig = {
+    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
+    extra-substituters = "https://devenv.cachix.org";
+  };
+
+  outputs = inputs @ {
+    flake-parts,
+    devenv-root,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [
+        inputs.devenv.flakeModule
+      ];
+      systems = [
+        "x86_64-linux"
+        "i686-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        sets = import ./pkgs-sets.nix {inherit inputs' system;};
+      in {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
+
+        # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
+        packages.default = pkgs.git;
+
+        devenv.shells.default = {
+          name = "sonarqube-zed-extension";
+
+          _module.args = sets;
+
+          imports = [
+            # This is just like the imports in devenv.nix.
+            # See https://devenv.sh/guides/using-with-flake-parts/#import-a-devenv-module
+            # ./devenv-foo.nix
+            ./rust.nix
+          ];
+
+          # https://devenv.sh/reference/options/
+          packages = [config.packages.default];
+
+          enterShell = ''
+
+          '';
+        };
+      };
+      flake = {
+        # The usual flake attributes can be defined here, including system-
+        # agnostic ones like nixosModule and system-enumerating ones, although
+        # those are more easily expressed in perSystem.
+      };
+    };
+}

--- a/nix/pkgs-sets.nix
+++ b/nix/pkgs-sets.nix
@@ -1,0 +1,6 @@
+{
+  inputs',
+  system,
+}: {
+  upkgs = inputs'.nixpkgs-unstable.legacyPackages;
+}

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,0 +1,9 @@
+{pkgs, ...}: {
+  languages.rust = {
+    enable = true;
+    channel = "stable";
+    targets = [
+      "wasm32-wasip2"
+    ];
+  };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,10 +191,6 @@ impl zed::Extension for SonarLintExtension {
                 "SONARLINT_ANALYZER_PATHS".to_string(),
                 analyzer_paths.join("|"),
             ),
-            (
-                "SONARLINT_WORKSPACE_ROOT".to_string(),
-                worktree.root_path(),
-            ),
         ];
 
         if let Some(java_home) = worktree.shell_env().iter().find(|(k, _)| k == "JAVA_HOME") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ use zed_extension_api::{
 };
 
 const SONARLINT_VSCODE_REPO: &str = "SonarSource/sonarlint-vscode";
-const SONARLINT_VERSION: &str = "4.42.0";
-const SONARLINT_TAG: &str = concatcp!(SONARLINT_VERSION, "+79846");
+const SONARLINT_VERSION: &str = "5.3.0";
+const SONARLINT_TAG: &str = concatcp!(SONARLINT_VERSION, "+80328");
 const SONARLINT_ASSET_NAME: &str = concatcp!("sonarlint-vscode-", SONARLINT_VERSION, ".vsix");
 
 const SERVER_NAME: &str = "sonarlint-ls.jar";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,10 @@ impl zed::Extension for SonarLintExtension {
                 "SONARLINT_ANALYZER_PATHS".to_string(),
                 analyzer_paths.join("|"),
             ),
+            (
+                "SONARLINT_WORKSPACE_ROOT".to_string(),
+                worktree.root_path(),
+            ),
         ];
 
         if let Some(java_home) = worktree.shell_env().iter().find(|(k, _)| k == "JAVA_HOME") {

--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -158,6 +158,11 @@ const RAW_ANALYZERS = (
   .filter(Boolean);
 const JAVA_HOME = process.env.JAVA_HOME || "";
 const DEBUG = process.env.SONARLINT_DEBUG === "1";
+const WORKSPACE_ROOT =
+  process.env.SONARLINT_WORKSPACE_ROOT &&
+  fs.existsSync(process.env.SONARLINT_WORKSPACE_ROOT)
+    ? process.env.SONARLINT_WORKSPACE_ROOT
+    : process.cwd();
 
 if (!RAW_SERVER_JAR) {
   process.stderr.write(
@@ -184,8 +189,127 @@ function log(...args) {
   logStream.write(line);
 }
 
+// ─── SonarJS bridge path casing workaround ───────────────────────────────────
+
+/**
+ * SonarJS may normalize paths to lowercase for comparison and then later reuse
+ * those normalized values for filesystem reads. This breaks on case-sensitive
+ * volumes because the real workspace path casing must be preserved.
+ *
+ * The hook below is loaded only into Node.js child processes spawned by the Java
+ * language server. It rewrites paths under a lowercased workspace root back to
+ * the original workspace-root casing before fs reads.
+ */
+function writePathCaseFixHook() {
+  const os = require("os");
+  const hookPath = path.join(os.tmpdir(), "sonarlint-node-path-case-fix.js");
+
+  fs.writeFileSync(
+    hookPath,
+    String.raw`
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const originalAppendFileSync = fs.appendFileSync;
+const DEBUG = process.env.SONARLINT_DEBUG === "1";
+const LOG_PATH = process.env.SONARLINT_CASE_FIX_LOG || "";
+const WORKSPACE_ROOT = process.env.SONARLINT_WORKSPACE_ROOT || "";
+const LOWER_WORKSPACE_ROOT = WORKSPACE_ROOT.toLowerCase();
+
+function log(...parts) {
+  if (!DEBUG || !LOG_PATH) return;
+
+  try {
+    originalAppendFileSync.call(
+      fs,
+      LOG_PATH,
+      "[" + new Date().toISOString() + " pid=" + process.pid + "] " + parts.map(String).join(" ") + "\n",
+    );
+  } catch {
+    // Never break SonarLint because workaround logging failed.
+  }
+}
+
+function fixPath(value) {
+  if (typeof value !== "string" || !WORKSPACE_ROOT) {
+    return value;
+  }
+
+  const lower = value.toLowerCase();
+
+  if (lower === LOWER_WORKSPACE_ROOT) {
+    if (value !== WORKSPACE_ROOT) {
+      log("fix", value, "=>", WORKSPACE_ROOT);
+    }
+    return WORKSPACE_ROOT;
+  }
+
+  if (lower.startsWith(LOWER_WORKSPACE_ROOT + path.sep)) {
+    const fixed = WORKSPACE_ROOT + value.slice(LOWER_WORKSPACE_ROOT.length);
+    if (fixed !== value) {
+      log("fix", value, "=>", fixed);
+    }
+    return fixed;
+  }
+
+  return value;
+}
+
+function patchSync(name) {
+  const original = fs[name];
+  if (typeof original !== "function") return;
+
+  fs[name] = function patchedPathFunction(value, ...args) {
+    return original.call(this, fixPath(value), ...args);
+  };
+}
+
+for (const name of [
+  "readFileSync",
+  "existsSync",
+  "statSync",
+  "lstatSync",
+  "accessSync",
+  "openSync",
+  "readdirSync",
+  "realpathSync",
+]) {
+  patchSync(name);
+}
+
+if (fs.realpathSync && typeof fs.realpathSync.native === "function") {
+  const originalNativeRealpathSync = fs.realpathSync.native;
+  fs.realpathSync.native = function patchedNativeRealpathSync(value, ...args) {
+    return originalNativeRealpathSync.call(this, fixPath(value), ...args);
+  };
+}
+
+const originalReadFile = fs.readFile;
+fs.readFile = function patchedReadFile(value, ...args) {
+  return originalReadFile.call(this, fixPath(value), ...args);
+};
+
+if (fs.promises && typeof fs.promises.readFile === "function") {
+  const originalPromisesReadFile = fs.promises.readFile.bind(fs.promises);
+  fs.promises.readFile = function patchedPromisesReadFile(value, ...args) {
+    return originalPromisesReadFile(fixPath(value), ...args);
+  };
+}
+
+log("case-fix loaded");
+log("workspace root", WORKSPACE_ROOT);
+`,
+    "utf8",
+  );
+
+  return hookPath;
+}
+
 log("=== Wrapper started ===");
 log("CWD:", process.cwd());
+log("WORKSPACE_ROOT:", WORKSPACE_ROOT);
 log("SERVER_JAR:", SERVER_JAR);
 log("exists:", fs.existsSync(SERVER_JAR));
 log("JAVA_PATH:", JAVA_PATH);
@@ -339,9 +463,26 @@ if (JAVA_HOME) {
   javaEnv.JAVA_HOME = JAVA_HOME;
 }
 
+javaEnv.SONARLINT_WORKSPACE_ROOT = WORKSPACE_ROOT;
+
+if (DEBUG) {
+  javaEnv.SONARLINT_CASE_FIX_LOG = LOG_PATH;
+}
+
+const pathCaseFixHook = writePathCaseFixHook();
+
+javaEnv.NODE_OPTIONS = [
+  javaEnv.NODE_OPTIONS || "",
+  `--require=${pathCaseFixHook}`,
+]
+  .filter(Boolean)
+  .join(" ");
+
 log("Starting:", JAVA_PATH, javaArgs.join(" "));
+log("JAVA NODE_OPTIONS:", javaEnv.NODE_OPTIONS);
 
 const serverProcess = spawn(JAVA_PATH, javaArgs, {
+  cwd: WORKSPACE_ROOT,
   stdio: ["pipe", "pipe", "pipe"],
   env: javaEnv,
 });
@@ -620,25 +761,31 @@ function findSharedConfigForScope(scopeUri) {
 
 /**
  * Qualify a project key for SonarCloud connections.
- * SonarCloud project keys must be in the format "<organizationKey>_<projectKey>".
- * If the connection is SonarCloud and the project key doesn't already have the org prefix,
- * prepend it automatically.
- * Returns the (possibly prefixed) project key.
+ *
+ * Some SonarCloud projects use keys in the format "<organizationKey>_<projectKey>".
+ * To preserve compatibility with that convention, bare SonarCloud project keys
+ * are prefixed with the matching organization key.
+ *
+ * Project keys that already contain "_" are assumed to already be exact keys or
+ * underscore-separated keys and are left unchanged.
  */
 function qualifyProjectKey(connectionId, projectKey) {
   if (!connectionId || !projectKey) return projectKey;
+
+  if (projectKey.includes("_")) {
+    log(
+      `SonarCloud project key already contains "_"; leaving unchanged: "${projectKey}"`,
+    );
+    return projectKey;
+  }
 
   // Find the matching SonarCloud connection
   for (const conn of connectionConfigs.sonarcloud || []) {
     const connId = conn.connectionId || conn.organizationKey;
     if (connId === connectionId && conn.organizationKey) {
-      const prefix = conn.organizationKey + "_";
-      if (!projectKey.startsWith(prefix)) {
-        const qualified = prefix + projectKey;
-        log(`Qualified SonarCloud project key: "${projectKey}" → "${qualified}"`);
-        return qualified;
-      }
-      break;
+      const qualified = conn.organizationKey + "_" + projectKey;
+      log(`Qualified SonarCloud project key: "${projectKey}" → "${qualified}"`);
+      return qualified;
     }
   }
 

--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -189,127 +189,9 @@ function log(...args) {
   logStream.write(line);
 }
 
-// ─── SonarJS bridge path casing workaround ───────────────────────────────────
-
-/**
- * SonarJS may normalize paths to lowercase for comparison and then later reuse
- * those normalized values for filesystem reads. This breaks on case-sensitive
- * volumes because the real workspace path casing must be preserved.
- *
- * The hook below is loaded only into Node.js child processes spawned by the Java
- * language server. It rewrites paths under a lowercased workspace root back to
- * the original workspace-root casing before fs reads.
- */
-function writePathCaseFixHook() {
-  const os = require("os");
-  const hookPath = path.join(os.tmpdir(), "sonarlint-node-path-case-fix.js");
-
-  fs.writeFileSync(
-    hookPath,
-    String.raw`
-"use strict";
-
-const fs = require("fs");
-const path = require("path");
-
-const originalAppendFileSync = fs.appendFileSync;
-const DEBUG = process.env.SONARLINT_DEBUG === "1";
-const LOG_PATH = process.env.SONARLINT_CASE_FIX_LOG || "";
-const WORKSPACE_ROOT = process.env.SONARLINT_WORKSPACE_ROOT || "";
-const LOWER_WORKSPACE_ROOT = WORKSPACE_ROOT.toLowerCase();
-
-function log(...parts) {
-  if (!DEBUG || !LOG_PATH) return;
-
-  try {
-    originalAppendFileSync.call(
-      fs,
-      LOG_PATH,
-      "[" + new Date().toISOString() + " pid=" + process.pid + "] " + parts.map(String).join(" ") + "\n",
-    );
-  } catch {
-    // Never break SonarLint because workaround logging failed.
-  }
-}
-
-function fixPath(value) {
-  if (typeof value !== "string" || !WORKSPACE_ROOT) {
-    return value;
-  }
-
-  const lower = value.toLowerCase();
-
-  if (lower === LOWER_WORKSPACE_ROOT) {
-    if (value !== WORKSPACE_ROOT) {
-      log("fix", value, "=>", WORKSPACE_ROOT);
-    }
-    return WORKSPACE_ROOT;
-  }
-
-  if (lower.startsWith(LOWER_WORKSPACE_ROOT + path.sep)) {
-    const fixed = WORKSPACE_ROOT + value.slice(LOWER_WORKSPACE_ROOT.length);
-    if (fixed !== value) {
-      log("fix", value, "=>", fixed);
-    }
-    return fixed;
-  }
-
-  return value;
-}
-
-function patchSync(name) {
-  const original = fs[name];
-  if (typeof original !== "function") return;
-
-  fs[name] = function patchedPathFunction(value, ...args) {
-    return original.call(this, fixPath(value), ...args);
-  };
-}
-
-for (const name of [
-  "readFileSync",
-  "existsSync",
-  "statSync",
-  "lstatSync",
-  "accessSync",
-  "openSync",
-  "readdirSync",
-  "realpathSync",
-]) {
-  patchSync(name);
-}
-
-if (fs.realpathSync && typeof fs.realpathSync.native === "function") {
-  const originalNativeRealpathSync = fs.realpathSync.native;
-  fs.realpathSync.native = function patchedNativeRealpathSync(value, ...args) {
-    return originalNativeRealpathSync.call(this, fixPath(value), ...args);
-  };
-}
-
-const originalReadFile = fs.readFile;
-fs.readFile = function patchedReadFile(value, ...args) {
-  return originalReadFile.call(this, fixPath(value), ...args);
-};
-
-if (fs.promises && typeof fs.promises.readFile === "function") {
-  const originalPromisesReadFile = fs.promises.readFile.bind(fs.promises);
-  fs.promises.readFile = function patchedPromisesReadFile(value, ...args) {
-    return originalPromisesReadFile(fixPath(value), ...args);
-  };
-}
-
-log("case-fix loaded");
-log("workspace root", WORKSPACE_ROOT);
-`,
-    "utf8",
-  );
-
-  return hookPath;
-}
-
 log("=== Wrapper started ===");
 log("CWD:", process.cwd());
-log("WORKSPACE_ROOT:", WORKSPACE_ROOT);
+log("WORKSPACE_ROOT:", WORKSPACE_ROOT);``
 log("SERVER_JAR:", SERVER_JAR);
 log("exists:", fs.existsSync(SERVER_JAR));
 log("JAVA_PATH:", JAVA_PATH);
@@ -469,14 +351,7 @@ if (DEBUG) {
   javaEnv.SONARLINT_CASE_FIX_LOG = LOG_PATH;
 }
 
-const pathCaseFixHook = writePathCaseFixHook();
-
-javaEnv.NODE_OPTIONS = [
-  javaEnv.NODE_OPTIONS || "",
-  `--require=${pathCaseFixHook}`,
-]
-  .filter(Boolean)
-  .join(" ");
+javaEnv.NODE_OPTIONS = [javaEnv.NODE_OPTIONS || ""].filter(Boolean).join(" ");
 
 log("Starting:", JAVA_PATH, javaArgs.join(" "));
 log("JAVA NODE_OPTIONS:", javaEnv.NODE_OPTIONS);
@@ -532,7 +407,7 @@ function isFocusOnNewCodeEnabled() {
 
 function filterNewCodeDiagnostics(diagnostics) {
   if (!Array.isArray(diagnostics)) return diagnostics;
-  return diagnostics.filter(d => {
+  return diagnostics.filter((d) => {
     if (d.data == null || d.data.isOnNewCode === undefined) {
       return true; // Keep diagnostics without the field
     }
@@ -550,7 +425,7 @@ function filterNewCodeDiagnostics(diagnostics) {
 function remapDiagnosticSeverities(diagnostics) {
   if (!Array.isArray(diagnostics)) return diagnostics;
   for (const d of diagnostics) {
-    if (d.data != null && typeof d.data.impactSeverity === 'number') {
+    if (d.data != null && typeof d.data.impactSeverity === "number") {
       switch (d.data.impactSeverity) {
         case 4: // BLOCKER
         case 3: // HIGH
@@ -895,7 +770,12 @@ new LspMessageReader(serverProcess.stdout, (msg) => {
     remapDiagnosticSeverities(msg.params.diagnostics);
     if (isFocusOnNewCodeEnabled()) {
       msg.params.diagnostics = filterNewCodeDiagnostics(msg.params.diagnostics);
-      log("Filtered diagnostics for focusOnNewCode:", msg.params.diagnostics.length, "remaining for", msg.params.uri);
+      log(
+        "Filtered diagnostics for focusOnNewCode:",
+        msg.params.diagnostics.length,
+        "remaining for",
+        msg.params.uri,
+      );
     }
   }
 
@@ -1086,13 +966,15 @@ function handleServerRequest(msg) {
           if (!config.connectedMode?.project?.projectKey) {
             const sharedConfig = findSharedConfigForScope(item.scopeUri);
             if (sharedConfig?.projectKey) {
-              const connectionId =
-                matchConnectionForSharedConfig(sharedConfig);
+              const connectionId = matchConnectionForSharedConfig(sharedConfig);
               if (connectionId) {
                 config.connectedMode = config.connectedMode || {};
                 config.connectedMode.project = {
                   connectionId,
-                  projectKey: qualifyProjectKey(connectionId, sharedConfig.projectKey),
+                  projectKey: qualifyProjectKey(
+                    connectionId,
+                    sharedConfig.projectKey,
+                  ),
                 };
                 log(
                   `Auto-bound scope ${item.scopeUri || "(default)"} to connection=${connectionId} project=${config.connectedMode.project.projectKey} from shared config`,
@@ -1369,9 +1251,7 @@ function handleServerNotification(msg) {
       log("→ suggestConnection:", JSON.stringify(params));
       const suggestionsByScope =
         params?.suggestionsByConfigScopeId || params?.suggestions || {};
-      for (const [scopeId, suggestions] of Object.entries(
-        suggestionsByScope,
-      )) {
+      for (const [scopeId, suggestions] of Object.entries(suggestionsByScope)) {
         for (const suggestion of suggestions || []) {
           const conn = suggestion.connectionSuggestion || suggestion;
           const target = conn.serverUrl || conn.organization || "unknown";

--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -339,8 +339,6 @@ if (JAVA_HOME) {
   javaEnv.JAVA_HOME = JAVA_HOME;
 }
 
-javaEnv.NODE_OPTIONS = [javaEnv.NODE_OPTIONS || ""].filter(Boolean).join(" ");
-
 log("Starting:", JAVA_PATH, javaArgs.join(" "));
 
 const serverProcess = spawn(JAVA_PATH, javaArgs, {
@@ -1230,7 +1228,9 @@ function handleServerNotification(msg) {
       log("→ suggestConnection:", JSON.stringify(params));
       const suggestionsByScope =
         params?.suggestionsByConfigScopeId || params?.suggestions || {};
-      for (const [scopeId, suggestions] of Object.entries(suggestionsByScope)) {
+      for (const [scopeId, suggestions] of Object.entries(
+        suggestionsByScope,
+      )) {
         for (const suggestion of suggestions || []) {
           const conn = suggestion.connectionSuggestion || suggestion;
           const target = conn.serverUrl || conn.organization || "unknown";

--- a/wrapper/sonarlint-wrapper.js
+++ b/wrapper/sonarlint-wrapper.js
@@ -158,11 +158,6 @@ const RAW_ANALYZERS = (
   .filter(Boolean);
 const JAVA_HOME = process.env.JAVA_HOME || "";
 const DEBUG = process.env.SONARLINT_DEBUG === "1";
-const WORKSPACE_ROOT =
-  process.env.SONARLINT_WORKSPACE_ROOT &&
-  fs.existsSync(process.env.SONARLINT_WORKSPACE_ROOT)
-    ? process.env.SONARLINT_WORKSPACE_ROOT
-    : process.cwd();
 
 if (!RAW_SERVER_JAR) {
   process.stderr.write(
@@ -191,7 +186,6 @@ function log(...args) {
 
 log("=== Wrapper started ===");
 log("CWD:", process.cwd());
-log("WORKSPACE_ROOT:", WORKSPACE_ROOT);``
 log("SERVER_JAR:", SERVER_JAR);
 log("exists:", fs.existsSync(SERVER_JAR));
 log("JAVA_PATH:", JAVA_PATH);
@@ -345,19 +339,11 @@ if (JAVA_HOME) {
   javaEnv.JAVA_HOME = JAVA_HOME;
 }
 
-javaEnv.SONARLINT_WORKSPACE_ROOT = WORKSPACE_ROOT;
-
-if (DEBUG) {
-  javaEnv.SONARLINT_CASE_FIX_LOG = LOG_PATH;
-}
-
 javaEnv.NODE_OPTIONS = [javaEnv.NODE_OPTIONS || ""].filter(Boolean).join(" ");
 
 log("Starting:", JAVA_PATH, javaArgs.join(" "));
-log("JAVA NODE_OPTIONS:", javaEnv.NODE_OPTIONS);
 
 const serverProcess = spawn(JAVA_PATH, javaArgs, {
-  cwd: WORKSPACE_ROOT,
   stdio: ["pipe", "pipe", "pipe"],
   env: javaEnv,
 });
@@ -407,7 +393,7 @@ function isFocusOnNewCodeEnabled() {
 
 function filterNewCodeDiagnostics(diagnostics) {
   if (!Array.isArray(diagnostics)) return diagnostics;
-  return diagnostics.filter((d) => {
+  return diagnostics.filter(d => {
     if (d.data == null || d.data.isOnNewCode === undefined) {
       return true; // Keep diagnostics without the field
     }
@@ -425,7 +411,7 @@ function filterNewCodeDiagnostics(diagnostics) {
 function remapDiagnosticSeverities(diagnostics) {
   if (!Array.isArray(diagnostics)) return diagnostics;
   for (const d of diagnostics) {
-    if (d.data != null && typeof d.data.impactSeverity === "number") {
+    if (d.data != null && typeof d.data.impactSeverity === 'number') {
       switch (d.data.impactSeverity) {
         case 4: // BLOCKER
         case 3: // HIGH
@@ -770,12 +756,7 @@ new LspMessageReader(serverProcess.stdout, (msg) => {
     remapDiagnosticSeverities(msg.params.diagnostics);
     if (isFocusOnNewCodeEnabled()) {
       msg.params.diagnostics = filterNewCodeDiagnostics(msg.params.diagnostics);
-      log(
-        "Filtered diagnostics for focusOnNewCode:",
-        msg.params.diagnostics.length,
-        "remaining for",
-        msg.params.uri,
-      );
+      log("Filtered diagnostics for focusOnNewCode:", msg.params.diagnostics.length, "remaining for", msg.params.uri);
     }
   }
 
@@ -966,15 +947,13 @@ function handleServerRequest(msg) {
           if (!config.connectedMode?.project?.projectKey) {
             const sharedConfig = findSharedConfigForScope(item.scopeUri);
             if (sharedConfig?.projectKey) {
-              const connectionId = matchConnectionForSharedConfig(sharedConfig);
+              const connectionId =
+                matchConnectionForSharedConfig(sharedConfig);
               if (connectionId) {
                 config.connectedMode = config.connectedMode || {};
                 config.connectedMode.project = {
                   connectionId,
-                  projectKey: qualifyProjectKey(
-                    connectionId,
-                    sharedConfig.projectKey,
-                  ),
+                  projectKey: qualifyProjectKey(connectionId, sharedConfig.projectKey),
                 };
                 log(
                   `Auto-bound scope ${item.scopeUri || "(default)"} to connection=${connectionId} project=${config.connectedMode.project.projectKey} from shared config`,


### PR DESCRIPTION
when configuring project-keys that are already fully qualified, the patch-up
still ran causing the extension to send an incorrect project-key.

on macos case-sensitive file-systems, sonarjs normalizes paths to lowercase
and uses those normalized lowercase paths for fs reads. this breaks on
case-sensitive volumes, and can be worked around using a fix hook.

closes: #25, #26